### PR TITLE
Implement persistence loading for auto learning

### DIFF
--- a/paca_python/paca/learning/auto/engine.py
+++ b/paca_python/paca/learning/auto/engine.py
@@ -8,6 +8,7 @@ import asyncio
 import json
 import time
 import logging
+from dataclasses import fields
 from typing import List, Dict, Any, Optional, Set, Tuple
 from pathlib import Path
 import re
@@ -699,20 +700,87 @@ class AutoLearningSystem:
     def _load_learning_data(self) -> None:
         """학습 데이터 로드"""
         try:
+            loaded_learning_points: List[LearningPoint] = []
+            loaded_tactics: List[GeneratedTactic] = []
+            loaded_heuristics: List[GeneratedHeuristic] = []
+            loaded_metrics = self.metrics
+
             # 학습 포인트 로드
             learning_points_file = self.storage_path / "learning_points.json"
             if learning_points_file.exists():
                 with open(learning_points_file, 'r', encoding='utf-8') as f:
                     data = json.load(f)
-                    for item in data:
-                        if 'category' in item:
-                            item['category'] = LearningCategory(item['category'])
-                        # LearningPoint 객체 재생성 (간단한 버전)
-                        # 실제 구현에서는 더 정교한 역직렬화 필요
+                lp_fields = {field.name for field in fields(LearningPoint)}
+                for item in data:
+                    if not isinstance(item, dict):
+                        continue
 
-            # 전술/휴리스틱 로드도 유사하게 구현
+                    item_data = dict(item)
+                    if 'category' in item_data:
+                        try:
+                            item_data['category'] = LearningCategory(item_data['category'])
+                        except ValueError:
+                            logger.warning("Unknown learning category encountered during load: %s", item_data['category'])
+                            continue
 
-            # 오래된 데이터 정리
+                    filtered_item = {k: item_data.get(k) for k in lp_fields if k in item_data}
+                    try:
+                        loaded_learning_points.append(LearningPoint(**filtered_item))
+                    except (TypeError, ValueError) as e:
+                        logger.warning("Skipping invalid learning point entry: %s", e)
+
+            # 전술 로드
+            tactics_file = self.storage_path / "generated_tactics.json"
+            if tactics_file.exists():
+                with open(tactics_file, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                tactic_fields = {field.name for field in fields(GeneratedTactic)}
+                for item in data:
+                    if not isinstance(item, dict):
+                        continue
+
+                    filtered_item = {k: item.get(k) for k in tactic_fields if k in item}
+                    try:
+                        loaded_tactics.append(GeneratedTactic(**filtered_item))
+                    except (TypeError, ValueError) as e:
+                        logger.warning("Skipping invalid generated tactic entry: %s", e)
+
+            # 휴리스틱 로드
+            heuristics_file = self.storage_path / "generated_heuristics.json"
+            if heuristics_file.exists():
+                with open(heuristics_file, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                heuristic_fields = {field.name for field in fields(GeneratedHeuristic)}
+                for item in data:
+                    if not isinstance(item, dict):
+                        continue
+
+                    filtered_item = {k: item.get(k) for k in heuristic_fields if k in item}
+                    try:
+                        loaded_heuristics.append(GeneratedHeuristic(**filtered_item))
+                    except (TypeError, ValueError) as e:
+                        logger.warning("Skipping invalid generated heuristic entry: %s", e)
+
+            # 메트릭 로드
+            metrics_file = self.storage_path / "learning_metrics.json"
+            if metrics_file.exists():
+                with open(metrics_file, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+                metrics_fields = {field.name for field in fields(LearningMetrics)}
+                filtered_metrics = {k: data.get(k) for k in metrics_fields if k in data}
+                try:
+                    loaded_metrics = LearningMetrics(**filtered_metrics)
+                except (TypeError, ValueError) as e:
+                    logger.warning("Failed to load learning metrics, using defaults: %s", e)
+                    loaded_metrics = LearningMetrics()
+
+            # 상태 반영
+            self.learning_points = loaded_learning_points
+            self.generated_tactics = loaded_tactics
+            self.generated_heuristics = loaded_heuristics
+            self.metrics = loaded_metrics
+
+            # 오래된 데이터 정리 (상태 복원 후 실행)
             self._cleanup_old_learning_data()
 
         except Exception as e:

--- a/paca_python/tests/test_auto_learning_integration.py
+++ b/paca_python/tests/test_auto_learning_integration.py
@@ -1,5 +1,7 @@
 
 import sys
+import shutil
+from dataclasses import asdict
 from pathlib import Path
 
 import pytest
@@ -10,6 +12,19 @@ if str(PROJECT_ROOT) not in sys.path:
 
 
 from paca.system import PacaSystem
+from paca.learning.auto.types import LearningPattern, PatternType
+
+
+LEARNING_STORAGE = PROJECT_ROOT / "data" / "memory" / "learning"
+
+
+@pytest.fixture(autouse=True)
+def clean_learning_storage():
+    if LEARNING_STORAGE.exists():
+        shutil.rmtree(LEARNING_STORAGE)
+    yield
+    if LEARNING_STORAGE.exists():
+        shutil.rmtree(LEARNING_STORAGE)
 
 
 @pytest.mark.asyncio
@@ -44,3 +59,93 @@ async def test_auto_learning_generates_learning_points():
 
     finally:
         await system.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_auto_learning_persists_between_sessions():
+    system = PacaSystem()
+
+    initial_point_ids = []
+    initial_tactic_ids = []
+    initial_heuristic_ids = []
+    initial_metrics_snapshot = {}
+
+    try:
+        await system.config_manager.initialize()
+        system.config_manager.set_value("default", "llm.api_keys", [])
+
+        init_result = await system.initialize()
+        assert init_result.is_success
+        assert system.auto_learning_system is not None
+
+        auto_learning = system.auto_learning_system
+        auto_learning.learning_patterns = [
+            LearningPattern(
+                pattern_type=PatternType.SUCCESS,
+                keywords=["success"],
+                context_indicators=["context"],
+                confidence_threshold=0.1,
+                extraction_rule=""
+            ),
+            LearningPattern(
+                pattern_type=PatternType.FAILURE,
+                keywords=["failure"],
+                context_indicators=["context"],
+                confidence_threshold=0.1,
+                extraction_rule=""
+            ),
+        ]
+
+        success_message = "success context success message ensures successful handling of the task"
+        failure_message = "failure context failure sequence describing the persistent problem"
+
+        success_result = await system.process_message(success_message, user_id="tester")
+        assert success_result.is_success
+
+        failure_result = await system.process_message(failure_message, user_id="tester")
+        assert failure_result.is_success
+
+        for tactic in auto_learning.generated_tactics:
+            tactic.apply(success=True)
+        for heuristic in auto_learning.generated_heuristics:
+            heuristic.trigger(avoided=True)
+        await auto_learning._save_learning_data()
+
+        initial_point_ids = [lp.id for lp in auto_learning.learning_points]
+        initial_tactic_ids = [t.id for t in auto_learning.generated_tactics]
+        initial_heuristic_ids = [h.id for h in auto_learning.generated_heuristics]
+        initial_metrics_snapshot = asdict(auto_learning.metrics)
+
+        assert initial_point_ids, "학습 포인트가 저장되어야 합니다"
+        assert initial_tactic_ids, "자동 생성된 전술이 저장되어야 합니다"
+        assert initial_heuristic_ids, "자동 생성된 휴리스틱이 저장되어야 합니다"
+
+    finally:
+        await system.cleanup()
+
+    system_reloaded = PacaSystem()
+
+    try:
+        await system_reloaded.config_manager.initialize()
+        system_reloaded.config_manager.set_value("default", "llm.api_keys", [])
+
+        init_result = await system_reloaded.initialize()
+        assert init_result.is_success
+        assert system_reloaded.auto_learning_system is not None
+
+        auto_learning = system_reloaded.auto_learning_system
+        reloaded_point_ids = [lp.id for lp in auto_learning.learning_points]
+        reloaded_tactic_ids = [t.id for t in auto_learning.generated_tactics]
+        reloaded_heuristic_ids = [h.id for h in auto_learning.generated_heuristics]
+        reloaded_metrics_snapshot = asdict(auto_learning.metrics)
+
+        assert set(reloaded_point_ids) == set(initial_point_ids)
+        assert len(reloaded_point_ids) == len(initial_point_ids)
+        assert set(reloaded_tactic_ids) == set(initial_tactic_ids)
+        assert len(reloaded_tactic_ids) == len(initial_tactic_ids)
+        assert set(reloaded_heuristic_ids) == set(initial_heuristic_ids)
+        assert len(reloaded_heuristic_ids) == len(initial_heuristic_ids)
+        assert reloaded_metrics_snapshot == initial_metrics_snapshot
+
+    finally:
+        await system_reloaded.cleanup()


### PR DESCRIPTION
## Summary
- deserialize saved learning points, tactics, heuristics, and metrics when the auto learning engine boots
- ensure cleanup only runs after in-memory state and metrics are rebuilt
- add an integration test that forces generation of learning artifacts, restarts the system, and verifies they persist

## Testing
- pytest tests/test_auto_learning_integration.py -q

------
https://chatgpt.com/codex/tasks/task_e_68ddd41a7f04833385060e82b01b3629