### PR TITLE
Lazy initialize auto-learning save lock

### DIFF
--- a/paca_python/tests/test_auto_learning_async_io.py
+++ b/paca_python/tests/test_auto_learning_async_io.py
@@ -153,3 +153,17 @@ async def test_concurrent_saves_capture_mutations(tmp_path: Path):
 
     assert any(entry.get("metadata", {}).get("note") == "updated" for entry in tactics_data)
     assert any("conversation-2" in entry.get("source_conversations", []) for entry in heuristics_data)
+
+
+def test_auto_learning_system_instantiation_without_running_loop(tmp_path: Path):
+    system = AutoLearningSystem(
+        database=_StubDatabase(),
+        conversation_memory=_StubConversationMemory(),
+        storage_path=str(tmp_path),
+        enable_korean_nlp=False,
+    )
+
+    async def invoke_save() -> None:
+        await system._save_learning_data()
+
+    asyncio.run(invoke_save())


### PR DESCRIPTION
## Summary
- defer creation of the auto-learning save lock until the first asynchronous save
- guard the lazy-initialization path inside `_save_learning_data` to avoid race conditions
- add a regression test that constructs `AutoLearningSystem` in a synchronous context and exercises saving within an event loop

## Testing
- pytest paca_python/tests/test_auto_learning_async_io.py::test_auto_learning_system_instantiation_without_running_loop

------
https://chatgpt.com/codex/tasks/task_e_68dea09023c48333be31caac9d147e33