### PR TITLE
Handle asyncio locks across event loop recreations

### DIFF
--- a/paca_python/tests/test_auto_learning_async_io.py
+++ b/paca_python/tests/test_auto_learning_async_io.py
@@ -199,6 +199,23 @@ def test_file_learning_data_synchronizer_initializes_without_event_loop(tmp_path
     assert (tmp_path / "snapshot.json").exists(), "snapshot export should succeed without pre-running loop"
 
 
+def test_file_learning_data_synchronizer_survives_multiple_asyncio_run_calls(tmp_path: Path):
+    synchronizer = FileLearningDataSynchronizer(tmp_path / "snapshot.json")
+    snapshot = LearningDataSnapshot(
+        saved_at=time.time(),
+        learning_points=[],
+        generated_tactics=[],
+        generated_heuristics=[],
+        metrics={},
+    )
+
+    for _ in range(2):
+        asyncio.run(synchronizer.sync(snapshot))
+
+    payload = json.loads((tmp_path / "snapshot.json").read_text(encoding="utf-8"))
+    assert payload["learning_points"] == []
+
+
 class _RecordingSynchronizer:
     def __init__(self) -> None:
         self.snapshots = []


### PR DESCRIPTION
## Summary
- record the event loop used to create the OpsMonitoringBridge write lock and regenerate it when the loop changes
- apply the same loop tracking to FileLearningDataSynchronizer so snapshot exports survive repeated asyncio.run calls
- add regression tests that call asyncio.run multiple times on the same instances without raising errors

## Testing
- `PYTHONPATH=. pytest tests/phase2/test_operations_pipeline.py::test_ops_monitoring_bridge_survives_multiple_asyncio_run_calls tests/test_auto_learning_async_io.py::test_file_learning_data_synchronizer_survives_multiple_asyncio_run_calls`

------
https://chatgpt.com/codex/tasks/task_e_68deda9ead0083338b26749521fb87c5