### PR TITLE
Ensure async locks refresh event loop binding

### DIFF
--- a/paca_python/paca/learning/auto/synchronizer.py
+++ b/paca_python/paca/learning/auto/synchronizer.py
@@ -68,6 +68,9 @@ class FileLearningDataSynchronizer:
                 lock = self._lock
                 lock_loop = self._lock_loop
                 if _needs_new_lock(lock, lock_loop, current_loop):
+                    # Refresh the running loop reference under the guard so the
+                    # newly created lock is always bound to the active loop.
+                    current_loop = asyncio.get_running_loop()
                     lock = self._create_lock(current_loop)
 
         assert lock is not None

--- a/paca_python/paca/operations/monitoring_bridge.py
+++ b/paca_python/paca/operations/monitoring_bridge.py
@@ -69,6 +69,9 @@ class OpsMonitoringBridge:
                 lock = self._write_lock
                 lock_loop = self._write_lock_loop
                 if _needs_new_lock(lock, lock_loop, current_loop):
+                    # Refresh the running loop reference under the guard so the
+                    # newly created lock is always bound to the active loop.
+                    current_loop = asyncio.get_running_loop()
                     lock = self._create_write_lock(current_loop)
 
         assert lock is not None  # narrow Optional for type-checkers


### PR DESCRIPTION
## Summary
- refresh the running loop reference when recreating OpsMonitoringBridge's write lock so the new lock always binds to the active loop
- mirror the loop refresh logic for FileLearningDataSynchronizer to keep auto-learning persistence safe across repeated asyncio.run calls

## Testing
- pytest paca_python/tests/phase2/test_operations_pipeline.py -k asyncio_run -q
- pytest paca_python/tests/test_auto_learning_async_io.py -k asyncio_run -q

------
https://chatgpt.com/codex/tasks/task_e_68e02cd549748333b382ed00ab919b0f